### PR TITLE
Update Maven Dependencies to make the maven jar file work again

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,8 @@
 
     <repositories>
         <repository>
-            <id>bukkit</id>
-            <url>http://repo.bukkit.org/content/groups/public/</url>
+            <id>spigot-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
         <repository>
             <id>onarandombox</id>
@@ -30,11 +30,11 @@
     </repositories>
 
     <dependencies>
-        <!-- Bukkit -->
+        <!-- Spigot -->
         <dependency>
-            <groupId>org.bukkit</groupId>
-            <artifactId>bukkit</artifactId>
-            <version>1.4.7-R0.1</version>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.10.2-R0.1-SNAPSHOT</version>
             <type>jar</type>
             <scope>compile</scope>
         </dependency>


### PR DESCRIPTION
Currently the maven jar file for this project causes errors when compiling, because it uses bukkit as a dependency and the bukkit maven dependencies aren't online anymore. This PR changes it to use spigot's api which is most definitely still online.